### PR TITLE
Color 0x000000 is evaluated as 'False' and cause an UnboundLocalError

### DIFF
--- a/xtermcolor/ColorMap.py
+++ b/xtermcolor/ColorMap.py
@@ -26,9 +26,9 @@ class TerminalColorMap:
     if rgb is not None and ansi is not None:
       raise TerminalColorMapException('colorize: must specify only one named parameter: rgb or ansi')
 
-    if rgb:
+    if rgb is not None:
       (closestAnsi, closestRgb) = self.convert(rgb)
-    elif ansi:
+    elif ansi is not None:
       (closestAnsi, closestRgb) = (ansi, self.colors[ansi])
 
     return "\033[38;5;{ansiCode:d}m{string:s}\033[0m".format(ansiCode=closestAnsi, string=string)


### PR DESCRIPTION
When color 0x000000 is used, the following two conditions are evaluated as False:

```
if rgb:
      (closestAnsi, closestRgb) = self.convert(rgb)
elif ansi:
      (closestAnsi, closestRgb) = (ansi, self.colors[ansi])
```

This cause the last line

```
return "\033[38;5;{ansiCode:d}m{string:s}\033[0m".format(ansiCode=closestAnsi, string=string)
```

To raise an UnboundLocalError exception:

```
≫ python test.py        
Traceback (most recent call last):
  File "test.py", line 3, in <module>
    print(cmap.colorize('Hello World', 0x000000))
  File "/tmp/xtermcolor/xtermcolor/ColorMap.py", line 34, in colorize
    return "\033[38;5;{ansiCode:d}m{string:s}\033[0m".format(ansiCode=closestAnsi, string=string)
UnboundLocalError: local variable 'closestAnsi' referenced before assignment
```

Simple test case:

```
from xtermcolor.ColorMap import XTermColorMap
cmap = XTermColorMap()
print(cmap.colorize('Hello World', 0x000000))
```

Patch attached in pull request.
